### PR TITLE
Use the screen’s size instead of the window’s.

### DIFF
--- a/Example/IRLSizeExample/IRLViewController.m
+++ b/Example/IRLSizeExample/IRLViewController.m
@@ -74,6 +74,7 @@
 - (void)configureLabels
 {
     NSLengthFormatter *formatter = [[NSLengthFormatter alloc] init];
+    formatter.numberFormatter.maximumFractionDigits = 1;
     
     self.widthLabel.text = [formatter stringFromMeters:
                             [self.view irl_width]];

--- a/Pod/Classes/UIDevice+IRLSize.m
+++ b/Pod/Classes/UIDevice+IRLSize.m
@@ -62,7 +62,7 @@ static const NSUInteger kiPadProHeightPoints = 1366;
             convertedFrame = view.frame;
         }
         
-        CGSize windowSize = window.bounds.size;
+        CGSize windowSize = window.screen.bounds.size;
         
         if (window == nil) {
             if ([[UIScreen mainScreen] respondsToSelector:@selector(fixedCoordinateSpace)]) {


### PR DESCRIPTION
The size of the window can change under iOS 9 multitasking. Using the screen instead gives the entire size of the screen, no matter what.

Fixes #4.