### PR TITLE
Explicit support for 2017 iPads

### DIFF
--- a/Example/IRLSizeTests/IRLSizeTests.m
+++ b/Example/IRLSizeTests/IRLSizeTests.m
@@ -21,6 +21,41 @@ describe(@"Getting the native size of a device", ^{
     
     registerMatchers(@"IRL");
     
+    context(@"on an iPhone 4S", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPhone4S)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0740
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0493
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
     context(@"on an iPhone 5", ^{
         
         beforeEach(^{
@@ -195,41 +230,6 @@ describe(@"Getting the native size of a device", ^{
         
     });
     
-    context(@"on an iPhone 6s", ^{
-        
-        beforeEach(^{
-            
-            [SDiOSVersion stub:@selector(deviceVersion)
-                     andReturn:theValue(iPhone6S)];
-            
-        });
-        
-        it(@"should report the correct height", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1041
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
-             beWithin:0.01
-             ofMeasurement:expectedHeight];
-            
-        });
-        
-        it(@"should report the correct width", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.0585
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
-             beWithin:0.01
-             ofMeasurement:expectedWidth];
-            
-        });
-        
-    });
-    
     context(@"on an iPhone 6 Plus", ^{
         
         beforeEach(^{
@@ -300,19 +300,19 @@ describe(@"Getting the native size of a device", ^{
         
     });
     
-    context(@"on an iPad mini (2nd Generation)", ^{
+    context(@"on an iPhone 6s", ^{
         
         beforeEach(^{
             
             [SDiOSVersion stub:@selector(deviceVersion)
-                     andReturn:theValue(iPadMini2)];
+                     andReturn:theValue(iPhone6S)];
             
         });
         
         it(@"should report the correct height", ^{
             
             NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1605
+            [[NSMeasurement alloc] initWithDoubleValue:0.1041
                                                   unit:[NSUnitLength meters]];
             
             [[UIDevice.currentDevice.irl_physicalScreenHeight should]
@@ -324,7 +324,7 @@ describe(@"Getting the native size of a device", ^{
         it(@"should report the correct width", ^{
             
             NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1204
+            [[NSMeasurement alloc] initWithDoubleValue:0.0585
                                                   unit:[NSUnitLength meters]];
             
             [[UIDevice.currentDevice.irl_physicalScreenWidth should]
@@ -335,19 +335,19 @@ describe(@"Getting the native size of a device", ^{
         
     });
     
-    context(@"on an iPad mini (3rd Generation)", ^{
+    context(@"on an iPhone 7", ^{
         
         beforeEach(^{
             
             [SDiOSVersion stub:@selector(deviceVersion)
-                     andReturn:theValue(iPadMini3)];
+                     andReturn:theValue(iPhone7)];
             
         });
         
         it(@"should report the correct height", ^{
             
             NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1605
+            [[NSMeasurement alloc] initWithDoubleValue:0.1041
                                                   unit:[NSUnitLength meters]];
             
             [[UIDevice.currentDevice.irl_physicalScreenHeight should]
@@ -359,7 +359,7 @@ describe(@"Getting the native size of a device", ^{
         it(@"should report the correct width", ^{
             
             NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1204
+            [[NSMeasurement alloc] initWithDoubleValue:0.0585
                                                   unit:[NSUnitLength meters]];
             
             [[UIDevice.currentDevice.irl_physicalScreenWidth should]
@@ -370,19 +370,19 @@ describe(@"Getting the native size of a device", ^{
         
     });
     
-    context(@"on an iPad mini (4th Generation)", ^{
+    context(@"on an iPhone 7 Plus", ^{
         
         beforeEach(^{
             
             [SDiOSVersion stub:@selector(deviceVersion)
-                     andReturn:theValue(iPadMini4)];
+                     andReturn:theValue(iPhone7Plus)];
             
         });
         
         it(@"should report the correct height", ^{
             
             NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1605
+            [[NSMeasurement alloc] initWithDoubleValue:0.1218
                                                   unit:[NSUnitLength meters]];
             
             [[UIDevice.currentDevice.irl_physicalScreenHeight should]
@@ -394,7 +394,77 @@ describe(@"Getting the native size of a device", ^{
         it(@"should report the correct width", ^{
             
             NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1204
+            [[NSMeasurement alloc] initWithDoubleValue:0.0685
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on an iPad (2nd Generation)", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPad2)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1971
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1478
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on an iPad (3rd Generation)", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPad3)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1971
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1478
                                                   unit:[NSUnitLength meters]];
             
             [[UIDevice.currentDevice.irl_physicalScreenWidth should]
@@ -440,6 +510,41 @@ describe(@"Getting the native size of a device", ^{
         
     });
     
+    context(@"on an iPad mini", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPadMini)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1605
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1204
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
     context(@"on an iPad Air", ^{
         
         beforeEach(^{
@@ -465,6 +570,41 @@ describe(@"Getting the native size of a device", ^{
             
             NSMeasurement<NSUnitLength *> *expectedWidth =
             [[NSMeasurement alloc] initWithDoubleValue:0.1478
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on an iPad mini (2nd Generation)", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPadMini2)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1605
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1204
                                                   unit:[NSUnitLength meters]];
             
             [[UIDevice.currentDevice.irl_physicalScreenWidth should]
@@ -510,6 +650,41 @@ describe(@"Getting the native size of a device", ^{
         
     });
     
+    context(@"on an iPad mini (3rd Generation)", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPadMini3)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1605
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1204
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
     context(@"on a 9.7\" iPad Pro", ^{
         
         beforeEach(^{
@@ -535,56 +710,6 @@ describe(@"Getting the native size of a device", ^{
             
             NSMeasurement<NSUnitLength *> *expectedWidth =
             [[NSMeasurement alloc] initWithDoubleValue:0.1478
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
-             beWithin:0.01
-             ofMeasurement:expectedWidth];
-            
-        });
-        
-    });
-    
-    context(@"on a 10.5\" iPad Pro", ^{
-        
-        beforeEach(^{
-            
-            // TODO: When SDVersion updates, use the new device version.
-            
-            [SDiOSVersion stub:@selector(deviceVersion)
-                     andReturn:theValue(UnknownDevice)];
-            
-            UIScreen *mockScreen = [UIScreen mock];
-            [UIScreen stub:@selector(mainScreen)
-                 andReturn:mockScreen];
-            
-            KWMock <UICoordinateSpace> *mockCoordinateSpace =
-            [KWMock mockForProtocol:@protocol(UICoordinateSpace)];
-            
-            [mockScreen stub:@selector(fixedCoordinateSpace)
-                   andReturn:mockCoordinateSpace];
-            
-            [mockCoordinateSpace stub:@selector(bounds)
-                            andReturn:theValue(CGRectMake(0, 0, 834, 1112))];
-            
-        });
-        
-        it(@"should report the correct height", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.2134
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
-             beWithin:0.01
-             ofMeasurement:expectedHeight];
-            
-        });
-        
-        it(@"should report the correct width", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.16
                                                   unit:[NSUnitLength meters]];
             
             [[UIDevice.currentDevice.irl_physicalScreenWidth should]
@@ -630,12 +755,434 @@ describe(@"Getting the native size of a device", ^{
         
     });
     
+    context(@"on an iPad mini (4th Generation)", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPadMini4)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1605
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1204
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on an iPad (5th Generation)", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPad5)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1971
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1478
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on a 10.5\" iPad Pro", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPadPro10Dot5Inch)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.2134
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.16
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on a 12.9\" iPad Pro (2nd Generation)", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPadPro12Dot9Inch2Gen)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.2622
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1965
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+});
+
+describe(@"Estimating the size of an unknown device based on the screen size", ^{
+    
+    registerMatchers(@"IRL");
+    
+    __block UIScreen *mockScreen = nil;
+    __block NSObject <UICoordinateSpace> *mockCoordinateSpace = nil;
+    
+    beforeEach(^{
+        
+        [SDiOSVersion stub:@selector(deviceVersion)
+                 andReturn:theValue(Simulator)];
+        
+        mockScreen = [UIScreen mock];
+        mockCoordinateSpace = [KWMock mockForProtocol:@protocol(UICoordinateSpace)];
+        
+        [UIScreen stub:@selector(mainScreen) andReturn:mockScreen];
+        
+        [mockScreen stub:@selector(fixedCoordinateSpace)
+               andReturn:mockCoordinateSpace];
+        
+    });
+    
+    afterEach(^{
+        
+        mockScreen = nil;
+        
+    });
+    
+    context(@"on a device with a resolution of 320 ⨉ 480", ^{
+        
+        beforeEach(^{
+            
+            [mockCoordinateSpace stub:@selector(bounds)
+                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
+                                                          320.0f, 480.0))];
+            
+        });
+        
+        it(@"should estimate the height of a 3.5\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0740
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should estimate the width of a 3.5\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0493
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on a device with a resolution of 320 ⨉ 568", ^{
+        
+        beforeEach(^{
+            
+            [mockCoordinateSpace stub:@selector(bounds)
+                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
+                                                          320.0f, 568.0f))];
+            
+        });
+        
+        it(@"should estimate the height of a 4\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0885
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should estimate the width of a 4\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0499
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on a device with a resolution of 375 ⨉ 667", ^{
+        
+        beforeEach(^{
+            
+            [mockCoordinateSpace stub:@selector(bounds)
+                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
+                                                          375.0f, 667.0f))];
+            
+        });
+        
+        it(@"should estimate the height of a 4.7\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1041
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should estimate the width of a 4.7\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0585f
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on a device with a resolution of 414 ⨉ 736", ^{
+        
+        beforeEach(^{
+            
+            [mockCoordinateSpace stub:@selector(bounds)
+                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
+                                                          414.0f, 736.0f))];
+            
+        });
+        
+        it(@"should estimate the height of a 5.5\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1218
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should estimate the width of a 5.5\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0685
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on a device with a resolution of 768 ⨉ 1024", ^{
+        
+        beforeEach(^{
+            
+            [mockCoordinateSpace stub:@selector(bounds)
+                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
+                                                          768.0f, 1024.0f))];
+            
+        });
+        
+        it(@"should estimate the height of a 9.7\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1971
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should estimate the width of a 9.7\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1478
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on a device with a resolution of 834 ⨉ 1112", ^{
+        
+        beforeEach(^{
+            
+            [mockCoordinateSpace stub:@selector(bounds)
+                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
+                                                          834.0f, 1112.0f))];
+            
+        });
+        
+        it(@"should estimate the height of a 10.5\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.2134
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should estimate the width of a 10.5\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.16
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on a device with a resolution of 1024 ⨉ 1366", ^{
+        
+        beforeEach(^{
+            
+            [mockCoordinateSpace stub:@selector(bounds)
+                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
+                                                          1024.0f, 1366.0f))];
+            
+        });
+        
+        it(@"should estimate the height of a 12.9\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.2622
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should estimate the width of a 12.9\" device", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.1965
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
 });
 
 describe(@"Getting the IRL size of a view", ^{
     
     registerMatchers(@"IRL");
-
+    
     __block UIApplication *mockSharedApplication;
     __block UIScreen *mockMainScreen;
     __block UIWindow *mockWindow;
@@ -914,252 +1461,6 @@ describe(@"Getting the IRL size of a view", ^{
                 [[theValue(CGAffineTransformIsIdentity(transform)) should] beTrue];
                 
             });
-            
-        });
-        
-    });
-    
-});
-
-describe(@"Estimating the size of an unknown device based on the screen size", ^{
-    
-    registerMatchers(@"IRL");
-    
-    __block UIScreen *mockScreen = nil;
-    __block NSObject <UICoordinateSpace> *mockCoordinateSpace = nil;
-    
-    beforeEach(^{
-        
-        [SDiOSVersion stub:@selector(deviceVersion)
-                 andReturn:theValue(Simulator)];
-        
-        mockScreen = [UIScreen mock];
-        mockCoordinateSpace = [KWMock mockForProtocol:@protocol(UICoordinateSpace)];
-        
-        [UIScreen stub:@selector(mainScreen) andReturn:mockScreen];
-        
-        [mockScreen stub:@selector(fixedCoordinateSpace)
-               andReturn:mockCoordinateSpace];
-        
-    });
-    
-    afterEach(^{
-        
-        mockScreen = nil;
-        
-    });
-    
-    context(@"on a device with a resolution of 320 ⨉ 568", ^{
-        
-        beforeEach(^{
-            
-            [mockCoordinateSpace stub:@selector(bounds)
-                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
-                                                          320.0f, 568.0f))];
-            
-        });
-        
-        it(@"should estimate the height of a 4\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.0885
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
-             beWithin:0.01
-             ofMeasurement:expectedHeight];
-            
-        });
-        
-        it(@"should estimate the width of a 4\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.0499
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
-             beWithin:0.01
-             ofMeasurement:expectedWidth];
-            
-        });
-        
-    });
-    
-    context(@"on a device with a resolution of 375 ⨉ 667", ^{
-        
-        beforeEach(^{
-            
-            [mockCoordinateSpace stub:@selector(bounds)
-                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
-                                                          375.0f, 667.0f))];
-            
-        });
-        
-        it(@"should estimate the height of a 4.7\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1041
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
-             beWithin:0.01
-             ofMeasurement:expectedHeight];
-            
-        });
-        
-        it(@"should estimate the width of a 4.7\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.0585f
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
-             beWithin:0.01
-             ofMeasurement:expectedWidth];
-            
-        });
-        
-    });
-    
-    context(@"on a device with a resolution of 414 ⨉ 736", ^{
-        
-        beforeEach(^{
-            
-            [mockCoordinateSpace stub:@selector(bounds)
-                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
-                                                          414.0f, 736.0f))];
-            
-        });
-        
-        it(@"should estimate the height of a 5.5\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1218
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
-             beWithin:0.01
-             ofMeasurement:expectedHeight];
-            
-        });
-        
-        it(@"should estimate the width of a 5.5\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.0685
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
-             beWithin:0.01
-             ofMeasurement:expectedWidth];
-            
-        });
-        
-    });
-    
-    context(@"on a device with a resolution of 768 ⨉ 1024", ^{
-        
-        beforeEach(^{
-            
-            [mockCoordinateSpace stub:@selector(bounds)
-                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
-                                                          768.0f, 1024.0f))];
-            
-        });
-        
-        it(@"should estimate the height of a 9.7\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1971
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
-             beWithin:0.01
-             ofMeasurement:expectedHeight];
-            
-        });
-        
-        it(@"should estimate the width of a 9.7\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1478
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
-             beWithin:0.01
-             ofMeasurement:expectedWidth];
-            
-        });
-        
-    });
-    
-    context(@"on a device with a resolution of 834 ⨉ 1112", ^{
-        
-        beforeEach(^{
-            
-            [mockCoordinateSpace stub:@selector(bounds)
-                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
-                                                          834.0f, 1112.0f))];
-            
-        });
-        
-        it(@"should estimate the height of a 10.5\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.2134
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
-             beWithin:0.01
-             ofMeasurement:expectedHeight];
-            
-        });
-        
-        it(@"should estimate the width of a 10.5\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.16
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
-             beWithin:0.01
-             ofMeasurement:expectedWidth];
-            
-        });
-        
-    });
-    
-    context(@"on a device with a resolution of 1024 ⨉ 1366", ^{
-        
-        beforeEach(^{
-            
-            [mockCoordinateSpace stub:@selector(bounds)
-                            andReturn:theValue(CGRectMake(0.0f, 0.0f,
-                                                          1024.0f, 1366.0f))];
-            
-        });
-        
-        it(@"should estimate the height of a 12.9\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedHeight =
-            [[NSMeasurement alloc] initWithDoubleValue:0.2622
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
-             beWithin:0.01
-             ofMeasurement:expectedHeight];
-            
-        });
-        
-        it(@"should estimate the width of a 12.9\" device", ^{
-            
-            NSMeasurement<NSUnitLength *> *expectedWidth =
-            [[NSMeasurement alloc] initWithDoubleValue:0.1965
-                                                  unit:[NSUnitLength meters]];
-            
-            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
-             beWithin:0.01
-             ofMeasurement:expectedWidth];
             
         });
         

--- a/Example/IRLSizeTests/IRLSizeTests.m
+++ b/Example/IRLSizeTests/IRLSizeTests.m
@@ -895,6 +895,76 @@ describe(@"Getting the native size of a device", ^{
         
     });
     
+    context(@"on an iPod touch (5th Generation)", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPodTouch5Gen)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0885
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0499
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
+    context(@"on an iPod touch (6th Generation)", ^{
+        
+        beforeEach(^{
+            
+            [SDiOSVersion stub:@selector(deviceVersion)
+                     andReturn:theValue(iPodTouch6Gen)];
+            
+        });
+        
+        it(@"should report the correct height", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedHeight =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0885
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenHeight should]
+             beWithin:0.01
+             ofMeasurement:expectedHeight];
+            
+        });
+        
+        it(@"should report the correct width", ^{
+            
+            NSMeasurement<NSUnitLength *> *expectedWidth =
+            [[NSMeasurement alloc] initWithDoubleValue:0.0499
+                                                  unit:[NSUnitLength meters]];
+            
+            [[UIDevice.currentDevice.irl_physicalScreenWidth should]
+             beWithin:0.01
+             ofMeasurement:expectedWidth];
+            
+        });
+        
+    });
+    
 });
 
 describe(@"Estimating the size of an unknown device based on the screen size", ^{

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - IRLSize (1.1.1):
+  - IRLSize (1.1.2):
     - SDVersion (~> 4.1.0)
   - Kiwi (2.4.0)
   - SDVersion (4.1)
@@ -13,7 +13,7 @@ EXTERNAL SOURCES:
     :path: ".."
 
 SPEC CHECKSUMS:
-  IRLSize: 9ca8b7929a702dfc4a84ae9da84bd49bf3b45e02
+  IRLSize: a8447f6ff05f4c16dbe818f02f08e9484e24e48a
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
   SDVersion: 6fb2b3b12e8c1b5dbceefa3da4613b2c245a0afd
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - IRLSize (1.1.1):
-    - SDVersion (~> 4.0.2)
+    - SDVersion (~> 4.1.0)
   - Kiwi (2.4.0)
-  - SDVersion (4.0.2)
+  - SDVersion (4.1)
 
 DEPENDENCIES:
   - IRLSize (from `..`)
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   IRLSize: 9ca8b7929a702dfc4a84ae9da84bd49bf3b45e02
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
-  SDVersion: 7b472a749907c29fcba04dadb8ecb4eb9a9aeeab
+  SDVersion: 6fb2b3b12e8c1b5dbceefa3da4613b2c245a0afd
 
 PODFILE CHECKSUM: 24be737e1d2c08b86ebee103a00184355b769706
 

--- a/IRLSize.podspec
+++ b/IRLSize.podspec
@@ -27,5 +27,5 @@ Pod::Spec.new do |s|
   s.watchos.source_files = 'Pod/Classes/watchOS/*'
   s.watchos.frameworks = 'Foundation', 'WatchKit'
 
-  s.dependency 'SDVersion', '~> 4.0.2'
+  s.dependency 'SDVersion', '~> 4.1.0'
 end

--- a/IRLSize.podspec
+++ b/IRLSize.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "IRLSize"
-  s.version          = "1.1.1"
+  s.version          = "1.1.2"
   s.summary          = "A library for determining the actual physical size of pixels on an iOS or watchOS device."
   s.description      = <<-DESC
                        IRLSize is used to determine the physical size of the device

--- a/Pod/Classes/iOS/UIDevice+IRLSize.m
+++ b/Pod/Classes/iOS/UIDevice+IRLSize.m
@@ -145,12 +145,7 @@ static const NSUInteger kiPadPro12Dot9InchHeightPoints = 1366;
     IRLRawSize size = { 0.0f, 0.0f };
     
     switch ([SDiOSVersion deviceVersion]) {
-        case iPhone4:
         case iPhone4S:
-        case iPodTouch1Gen:
-        case iPodTouch2Gen:
-        case iPodTouch3Gen:
-        case iPodTouch4Gen:
             size.width = kiPhone3_5InchScreenWidth;
             size.height = kiPhone3_5InchScreenHeight;
             break;
@@ -179,7 +174,6 @@ static const NSUInteger kiPadPro12Dot9InchHeightPoints = 1366;
             size.height = kiPhone5_5InchScreenHeight;
             break;
             
-        case iPad1:
         case iPad2:
         case iPad3:
         case iPad4:

--- a/Pod/Classes/iOS/UIDevice+IRLSize.m
+++ b/Pod/Classes/iOS/UIDevice+IRLSize.m
@@ -35,7 +35,7 @@ static const float kiPad7_9InchScreenWidth = 0.1204f;
 static const float kiPad9_7InchScreenHeight = 0.1971f;
 static const float kiPad9_7InchScreenWidth = 0.1478f;
 static const float kiPad10_5InchScreenHeight = 0.2134f;
-static const float kiPad10_5ScreenWidth = 0.16f;
+static const float kiPad10_5InchScreenWidth = 0.16f;
 static const float kiPad12_9InchScreenHeight = 0.2622f;
 static const float kiPad12_9InchScreenWidth = 0.1965f;
 
@@ -127,7 +127,7 @@ static const NSUInteger kiPadPro12Dot9InchHeightPoints = 1366;
             break;
             
         case kiPadPro10Dot5InchHeightPoints:
-            estimatedDimensions.width = kiPad10_5ScreenWidth;
+            estimatedDimensions.width = kiPad10_5InchScreenWidth;
             estimatedDimensions.height = kiPad10_5InchScreenHeight;
             break;
             
@@ -153,6 +153,7 @@ static const NSUInteger kiPadPro12Dot9InchHeightPoints = 1366;
         case iPodTouch4Gen:
             size.width = kiPhone3_5InchScreenWidth;
             size.height = kiPhone3_5InchScreenHeight;
+            break;
             
         case iPhone5:
         case iPhone5S:
@@ -198,7 +199,13 @@ static const NSUInteger kiPadPro12Dot9InchHeightPoints = 1366;
             size.height = kiPad7_9InchScreenHeight;
             break;
             
+        case iPadPro10Dot5Inch:
+            size.width = kiPad10_5InchScreenWidth;
+            size.height = kiPad10_5InchScreenHeight;
+            break;
+            
         case iPadPro12Dot9Inch:
+        case iPadPro12Dot9Inch2Gen:
             size.width = kiPad12_9InchScreenWidth;
             size.height = kiPad12_9InchScreenHeight;
             break;


### PR DESCRIPTION
Also adds tests for all devices compatible with iOS 8+, and fixes a bug with 3.5" devices.